### PR TITLE
drivers: wifi: esp8266: numaker: Support numaker_pfm_m467 board

### DIFF
--- a/boards/arm/numaker_pfm_m467/numaker_pfm_m467.dts
+++ b/boards/arm/numaker_pfm_m467/numaker_pfm_m467.dts
@@ -24,7 +24,7 @@
     
 	chosen {
 		zephyr,console = &uart0;
-		zephyr,shell = &uart0;
+		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
    		zephyr,code-partition = &slot0_partition;

--- a/boards/shields/esp_8266/boards/numaker_pfm_m467.conf
+++ b/boards/shields/esp_8266/boards/numaker_pfm_m467.conf
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Without enable, ESP8266 shield will continuously push data to board (+IPD) anyway
+# on receive and board's Rx buffer can get OOM easily. However, current driver
+# implementation on Passive Receive mode has the following concerns:
+# 1. On <conn_id>,CLOSED, driver closes the socket prematurely and buffered Rx data on
+#    ESP8266 shield gets unable to fetch (AT+RECVDATA).
+#    NOTE: To re-produce the issue, go samples/net/sockets/http_get in which the server
+#          end will close the connection immediately after replying the http response.
+# 2. On +IPD, driver doesn't consider available Rx buffer and straight schedules to fetch
+#    buffered Rx data on ESP8266 shield, still causing Rx buffer OOM. One approach may
+#    pre-allocate Rx buffer before the schedule.
+#    NOTE: To re-produce the issue, go samples/net/sockets/big_http_download/src, adding
+#          delay e.g. k_msleep(8000) in the download() while loop.
+#    NOTE: With or without this feature enabled, esp_socket_prepare_pkt() enabling timed
+#          wait (CONFIG_WIFI_ESP_AT_RX_NET_PKT_ALLOC_TIMEOUT) can relieve the problem to
+#          some degree.
+#
+# See: https://github.com/zephyrproject-rtos/zephyr/issues/52702
+#CONFIG_WIFI_ESP_AT_PASSIVE_MODE=y

--- a/boards/shields/esp_8266/boards/numaker_pfm_m467.overlay
+++ b/boards/shields/esp_8266/boards/numaker_pfm_m467.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+    uart2_esp8266: uart2_esp8266 {
+        pinmux = <PC1MFP_UART2_TXD 0x0000>,     /* UART2 TX */
+                 <PC0MFP_UART2_RXD 0x0000>,     /* UART2 RX */
+                 <PC3MFP_UART2_nRTS 0x0000>,    /* UART2 RTS */
+                 <PC2MFP_UART2_nCTS 0x0000>;    /* UART2 CTS */
+    };
+};
+
+&uart2 {
+    status = "okay";
+    current-speed = <115200>;
+    hw-flow-control;
+
+    pinctrl-0 = <&uart2_esp8266>;
+    pinctrl-names = "default";
+
+    esp8266: esp8266 {
+        compatible = "espressif,esp-at";
+        label = "esp8266";
+        status = "okay";
+        target-speed = <115200>;
+        reset-gpios = <&gpioc 4 GPIO_ACTIVE_LOW>;
+    };
+};
+
+&gpioc {
+    status = "okay";
+};


### PR DESCRIPTION
This PR tries to add ESP8266 shield support on M467 board, including:
1. Fix DT chosen node `zephyr,shell-uart`.
2. Support reset pin and UART flow control (CTS/RTS) for communication with ESP8266 shield.
3. Support and verify samples:
    - samples/net/sockets/http_get
    - samples/net/sockets/big_http_download

To build for `http_get`, run:
```
$ west -v build \
-b numaker_pfm_m467 \
zephyr/samples/net/sockets/http_get \
-- \
-DOVERLAY_CONFIG="overlay-wifi.conf" \
-DCONFIG_SAMPLE_HTTP_GET_WIFI_SSID="\"SSID\"" \
-DCONFIG_SAMPLE_HTTP_GET_WIFI_PSK="\"PASSWORD\"" \
-DSHIELD=esp_8266
```

To build for `big_http_download`, run:
```
$ west -v build \
-b numaker_pfm_m467 \
zephyr/samples/net/sockets/big_http_download \
-- \
-DOVERLAY_CONFIG="overlay-wifi.conf" \
-DCONFIG_SAMPLE_BIG_HTTP_DL_WIFI_SSID="\"SSID\"" \
-DCONFIG_SAMPLE_BIG_HTTP_DL_WIFI_PSK="\"PASSWORD\"" \
-DCONFIG_SAMPLE_BIG_HTTP_DL_NUM_ITER=3 \
-DSHIELD=esp_8266
```
