### PR TITLE
drivers: can: numaker: Fix compatible string

### DIFF
--- a/drivers/can/Kconfig.numaker
+++ b/drivers/can/Kconfig.numaker
@@ -3,7 +3,7 @@
 # Copyright (c) 2022 Nuvoton Technology Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_NUMAKER := nuvoton,numaker
+DT_COMPAT_NUMAKER := nuvoton,numaker-canfd
 
 config CAN_NUMAKER
 	bool "Nuvoton NuMaker CAN-FD driver"

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nuvoton_numaker
+#define DT_DRV_COMPAT nuvoton_numaker_canfd
 
 #include <soc.h>
 #include <zephyr/drivers/can.h>

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -515,7 +515,7 @@
 			tx-buffer-elements = <3>;
 
 			canfd0: canfd@40020000 {
-				compatible = "nuvoton,numaker";
+				compatible = "nuvoton,numaker-canfd";
 				reg = <0x40020000 0x200>, <0x40020200 0x1800>;
 				reg-names = "m_can", "message_ram";
 				interrupts = <112 0>, <113 0>;
@@ -530,7 +530,7 @@
 			};
 
 			canfd1: canfd@40024000 {
-				compatible = "nuvoton,numaker";
+				compatible = "nuvoton,numaker-canfd";
 				reg = <0x40024000 0x200>, <0x40024200 0x1800>;
 				reg-names = "m_can", "message_ram";
 				interrupts = <114 0>, <115 0>;
@@ -545,7 +545,7 @@
 			};
 
 			canfd2: canfd@40028000 {
-				compatible = "nuvoton,numaker";
+				compatible = "nuvoton,numaker-canfd";
 				reg = <0x40028000 0x200>, <0x40028200 0x1800>;
 				reg-names = "m_can", "message_ram";
 				interrupts = <120 0>, <121 0>;
@@ -560,7 +560,7 @@
 			};
 
 			canfd3: canfd@4002c000 {
-				compatible = "nuvoton,numaker";
+				compatible = "nuvoton,numaker-canfd";
 				reg = <0x4002c000 0x200>, <0x4002c200 0x1800>;
 				reg-names = "m_can", "message_ram";
 				interrupts = <122 0>, <123 0>;

--- a/dts/bindings/can/nuvoton,numaker-canfd.yaml
+++ b/dts/bindings/can/nuvoton,numaker-canfd.yaml
@@ -3,7 +3,7 @@
 
 description: Nuvoton NuMaker CAN-FD controller, using Bosch M_CAN IP
 
-compatible: "nuvoton,numaker"
+compatible: "nuvoton,numaker-canfd"
 
 include: ["can-fd-controller.yaml", "pinctrl-device.yaml"]
 


### PR DESCRIPTION
Continuing #6, this PR tries to fix compatible string to `nuvoton,numaker-canfd` from `nuvoton,numaker`.